### PR TITLE
Force the installation of Python 2 and pip2

### DIFF
--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,11 @@
 ---
 - hosts: all
-  name: Install pip3/python3 and remove pip2/python2
+  name: Install pip3/python3
   become: yes
   become_method: sudo
   roles:
     - pip
     - python
-    - remove_python2
+  vars:
+    install_pip2: true
+    install_python2: true

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  name: Install pip3/python3
+  name: Install python2/python3 and pip2/pip3
   become: yes
   become_method: sudo
   roles:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -15,7 +15,5 @@
   name: pip
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,7 +21,7 @@ def test_packages(host, pkg):
 @pytest.mark.parametrize("pkg", ["pymongo"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    assert pkg in host.pip_package.get_packages()
+    assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")
 
 
 @pytest.mark.parametrize(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,9 +19,15 @@ def test_packages(host, pkg):
 
 
 @pytest.mark.parametrize("pkg", ["pymongo"])
-def test_pip_packages(host, pkg):
-    """Test that the pip packages were installed."""
+def test_pip2_packages(host, pkg):
+    """Test that the pip2 packages were installed."""
     assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")
+
+
+@pytest.mark.parametrize("pkg", ["pymongo"])
+def test_pip3_packages(host, pkg):
+    """Test that the pip3 packages were installed."""
+    assert pkg in host.pip.get_packages()
 
 
 @pytest.mark.parametrize(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -27,7 +27,7 @@ def test_pip2_packages(host, pkg):
 @pytest.mark.parametrize("pkg", ["pymongo"])
 def test_pip3_packages(host, pkg):
     """Test that the pip3 packages were installed."""
-    assert pkg in host.pip.get_packages()
+    assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip3")
 
 
 @pytest.mark.parametrize(

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,4 +144,5 @@
 # pymongo is needed for the mongodb_user Ansible module
 - name: Install pymongo via pip
   ansible.builtin.pip:
+    executable: /usr/bin/pip2
     name: pymongo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,7 +142,10 @@
   when: test_runtimedirectorymode.rc != 0
 
 # pymongo is needed for the mongodb_user Ansible module
-- name: Install pymongo via pip
+- name: Install pymongo via pip2 and pip3
   ansible.builtin.pip:
-    executable: /usr/bin/pip2
+    executable: "{{ item }}"
     name: pymongo
+  loop:
+    - /usr/bin/pip2
+    - /usr/bin/pip3


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `molecule` `prepare` playbook to:
- Install Python 2
- Install `pip2`
- Stop removing Python 2 and `pip2`

## 💭 Motivation and context ##

This is required to fix the broken build since this Ansible role requires a Python 2 environment to function as intended.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.