### PR TITLE
Use new transparent huge pages role and make role able to install MongoDB again

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,9 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| version | Version of MongoDB to install. | `3.6` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ None.
 ## Dependencies ##
 
 - [cisagov/ansible-role-disable-numa](https://github.com/cisagov/ansible-role-disable-numa)
-- [GekoCloud/ansible-role-disable-thp](https://github.com/GekoCloud/ansible-role-disable-thp)
+- [cisagov/ansible-role-manage-thp](https://github.com/cisagov/ansible-role-manage-thp)
 - [cisagov/ansible-role-numactl](https://github.com/cisagov/ansible-role-numactl)
 - [cisagov/ansible-role-pip](https://github.com/cisagov/ansible-role-pip)
 - [cisagov/ansible-role-python](https://github.com/cisagov/ansible-role-python)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# The version of MongoDB to install.  Valid values are 3.2, 3.4, 3.6,
+# and 4.0.
+version: 3.6

--- a/files/mongodb-org-3.2.list
+++ b/files/mongodb-org-3.2.list
@@ -1,1 +1,0 @@
-deb [trusted=yes] https://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main

--- a/files/mongodb-org-3.2.list
+++ b/files/mongodb-org-3.2.list
@@ -1,1 +1,1 @@
-deb https://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main
+deb [trusted=yes] https://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main

--- a/files/mongodb-org-3.4.list
+++ b/files/mongodb-org-3.4.list
@@ -1,1 +1,1 @@
-deb https://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main
+deb [trusted=yes] https://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main

--- a/files/mongodb-org-3.4.list
+++ b/files/mongodb-org-3.4.list
@@ -1,1 +1,0 @@
-deb [trusted=yes] https://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main

--- a/files/mongodb-org-3.6.list
+++ b/files/mongodb-org-3.6.list
@@ -1,1 +1,1 @@
-deb https://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main
+deb [trusted=yes] https://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main

--- a/files/mongodb-org-3.6.list
+++ b/files/mongodb-org-3.6.list
@@ -1,1 +1,0 @@
-deb [trusted=yes] https://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main

--- a/files/mongodb-org-4.0.list
+++ b/files/mongodb-org-4.0.list
@@ -1,1 +1,0 @@
-deb [trusted=yes] https://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main

--- a/files/mongodb-org-4.0.list
+++ b/files/mongodb-org-4.0.list
@@ -1,1 +1,1 @@
-deb https://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main
+deb [trusted=yes] https://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,10 +11,12 @@ dependencies:
     name: disable_numa
   # MongoDB doesn't like transparent huge pages:
   # https://docs.mongodb.com/manual/tutorial/transparent-huge-pages/
-  - src: https://github.com/GekoCloud/ansible-role-disable-thp
-    name: disable_thp
+  - src: https://github.com/cisagov/ansible-role-manage-thp
+    name: manage_thp
     vars:
-      disable_thp_before_service: mongod
+      manage_thp_enabled_setting: never
+      manage_thp_start_before_service: mongod
+    version: first-commits
   - src: https://github.com/cisagov/ansible-role-numactl
     name: numactl
   - src: https://github.com/cisagov/ansible-role-pip

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,6 @@ dependencies:
     vars:
       manage_thp_enabled_setting: never
       manage_thp_start_before_service: mongod
-    version: first-commits
   - src: https://github.com/cisagov/ansible-role-numactl
     name: numactl
   - src: https://github.com/cisagov/ansible-role-pip

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -5,8 +5,9 @@
   src: https://github.com/cisagov/ansible-role-disable-numa
 # MongoDB doesn't like transparent huge pages:
 # https://docs.mongodb.com/manual/tutorial/transparent-huge-pages/
-- name: disable_thp
-  src: https://github.com/GekoCloud/ansible-role-disable-thp
+- name: manage_thp
+  src: https://github.com/cisagov/ansible-role-manage-thp
+  version: first-commits
 - name: numactl
   src: https://github.com/cisagov/ansible-role-numactl
 - name: pip

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -7,7 +7,6 @@
 # https://docs.mongodb.com/manual/tutorial/transparent-huge-pages/
 - name: manage_thp
   src: https://github.com/cisagov/ansible-role-manage-thp
-  version: first-commits
 - name: numactl
   src: https://github.com/cisagov/ansible-role-numactl
 - name: pip

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -15,7 +15,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 @pytest.mark.parametrize("pkg", ["mongodb-org"])
 def test_packages(host, pkg):
     """Test that the appropriate packages were installed."""
-    assert host.package(pkg).is_installed
+    p = host.package(pkg)
+    assert p.is_installed
+    assert p.version.startswith("3.6.23")
 
 
 @pytest.mark.parametrize("pkg", ["pymongo"])

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,13 +22,6 @@
       deb [trusted=yes] https://repo.mongodb.org/apt/debian
       stretch/mongodb-org/{{ version }} main
 
-- name: Update the cache with the mongodb-org goodness
-  ansible.builtin.package:
-    update_cache: true
-  tags:
-    # This task cannot be idempotent.
-    - molecule-idempotence-notest
-
 - name: Install mongo
   ansible.builtin.package:
     name: mongodb-org

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,11 @@
 #     id: 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
 #     keyserver: keyserver.ubuntu.com
 
+# TODO - Since the repo GPG key is expired, instead of trusting the
+# package repo we should instead download the package and store it in
+# S3.  This avoids the attack vector whereby a nefarious agent swaps
+# out the package at https://repo.mongodb.org/apt/debian for a
+# compromised one.  See #26 for more details.
 - name: Add Apt package repo for mongodb-org (official MongoDB package repo)
   ansible.builtin.apt_repository:
     filename: mongodb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,10 +8,12 @@
       - gnupg2
       - software-properties-common
 
-- name: Get mongodb-org GPG key
-  ansible.builtin.apt_key:
-    id: 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-    keyserver: keyserver.ubuntu.com
+# I'd love to do this, but the GPG key we're interested in expired in
+# December of 2023 and therefore fails to import.
+# - name: Get mongodb-org GPG key
+#   ansible.builtin.apt_key:
+#     id: 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+#     keyserver: keyserver.ubuntu.com
 
 - name: Copy sources list for mongodb-org (official MongoDB package repo)
   ansible.builtin.copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,9 @@
 - name: Update the cache with the mongodb-org goodness
   ansible.builtin.package:
     update_cache: true
+  tags:
+    # This task cannot be idempotent.
+    - molecule-idempotence-notest
 
 - name: Install mongo
   ansible.builtin.package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,11 +15,12 @@
 #     id: 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
 #     keyserver: keyserver.ubuntu.com
 
-- name: Copy sources list for mongodb-org (official MongoDB package repo)
-  ansible.builtin.copy:
-    dest: /etc/apt/sources.list.d
-    mode: 0644
-    src: mongodb-org-3.6.list
+- name: Add Apt package repo for mongodb-org (official MongoDB package repo)
+  ansible.builtin.apt_repository:
+    filename: mongodb
+    repo: >
+      deb [trusted=yes] https://repo.mongodb.org/apt/debian
+      stretch/mongodb-org/{{ version }} main
 
 - name: Update the cache with the mongodb-org goodness
   ansible.builtin.package:
@@ -30,7 +31,7 @@
 
 - name: Install mongo
   ansible.builtin.package:
-    name: mongodb-org=3.6.23
+    name: mongodb-org
 
 # Unless you do this, systemd can sometimes get confused when you try
 # to start a service you just installed


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the Ansible code to use the new transparent huge pages role created by @mcdonnnj instead of the old, unsupported one.  It also makes some changes to the Ansible role to allow it to once again install MongoDB.

## 💭 Motivation and context ##

The old THP role used some deprecated Ansible code, which was causing this role to fail its GitHub Actions.

Resolves #22 by making the role once gain able to install MongoDB..

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-approval checklist ##

- [x] Switch to using the default branch of [cisagov/ansible-role-manage-thp](cisagov/ansible-role-manage-thp) once cisagov/ansible-role-manage-thp#4 is merged.